### PR TITLE
fix: Dont crash for invalid regex

### DIFF
--- a/Kraki/Report/Message.fs
+++ b/Kraki/Report/Message.fs
@@ -3,13 +3,20 @@ module Message
 type Message =
     MissingKeyError of string
     | SchemaMismatchError of string
+    | RegexError of string
     | WrongOrderError of string
     | Info of string
+
+let private getTitle schema =
+    match Map.tryFind "title" schema with
+    | Some title -> $"schema '{title}'"
+    | None -> "untitled schema"
 
 let toString message =
     match message with
     | MissingKeyError e -> e
     | SchemaMismatchError e -> e
+    | RegexError e -> e
     | WrongOrderError e -> e
     | Info e -> e
 
@@ -17,11 +24,10 @@ let missingKey field =
     MissingKeyError $"Missing required key '{field}'"
 
 let schemaMismatch schema errors =
-    let description =
-        match Map.tryFind "title" schema with
-        | Some title -> $"schema '{title}'"
-        | None -> "untitled schema"
-    SchemaMismatchError $"Definition does not match {description}: {errors}"
+    SchemaMismatchError $"Definition does not match {getTitle schema}: {errors}"
+
+let regexError schema error =
+    RegexError $"Regex error in {getTitle schema}: {error}"
 
 let wrongSortOrder sortKeys expected =
     let sortOrder = String.concat " -> " sortKeys


### PR DESCRIPTION
## About

If an invalid Regex is provided in a `kraki` lint rule, `kraki` will throw an exception and crash. With the changes in this PR, exceptions are caught, and a meaningful error message is returned to the user.