### PR TITLE
chore: Add --format flag for list command

### DIFF
--- a/Kraki/Cli/Cli.fs
+++ b/Kraki/Cli/Cli.fs
@@ -15,12 +15,14 @@ type LintArgs =
 type ListArgs =
     { [<Option('g', "groupby", Default = "endpoint", HelpText = "A JSON field by which endpoints are grouped.")>]
       groupBy: string
+      [<Option('f', "format", Default = "padded", HelpText = "The output format of the endpoint list ('padded' or 'json').")>]
+      format: string
       [<Value(0, MetaName = "input file", Required = true, HelpText = "Path to the krakend config file.")>]
       inFile: string }
 
 let private runCommand (parsedArgs: obj) =
     match parsedArgs with
-    | :? ListArgs as args -> Command.list args.groupBy args.inFile
+    | :? ListArgs as args -> Command.list args.groupBy args.format args.inFile
     | :? LintArgs as args -> Command.lint args.configFile args.inFile
 
 let private parseArgs args =

--- a/Kraki/Cli/Command.fs
+++ b/Kraki/Cli/Command.fs
@@ -7,17 +7,17 @@ type LintResult = Pass of string | Fail of Report.Report
 let private loadConfig configParser path =
     File.read path >>= configParser
 
-let formatResult result =
+let formatResult (format: string) result =
     match result with
-    | Ok (Ok report) -> Ok (Report.toStatusMessage report)
-    | Ok (Error report) -> Error (Failure (Report.toErrorMessage report))
+    | Ok (Ok report) -> Ok (Report.toStatusMessage format report)
+    | Ok (Error report) -> Error (Failure (Report.toErrorMessage format report))
     | Error reason -> Error reason
 
-let list (groupBy: string) (krakendFile : string) =
+let list (groupBy: string) (format: string) (krakendFile : string) =
     let krakendCfg = loadConfig Krakend.parseConfig krakendFile
-    KrakiList.listBy groupBy <!> krakendCfg |> formatResult
+    KrakiList.listBy groupBy <!> krakendCfg |> formatResult format
 
 let lint (krakiFile : string) (krakendFile : string) =
     let krakendConfig = loadConfig Krakend.parseConfig krakendFile
     let krakiConfig = loadConfig Kraki.parseConfig krakiFile
-    KrakiLint.lint <!> krakiConfig <*> krakendConfig |> formatResult
+    KrakiLint.lint <!> krakiConfig <*> krakendConfig |> formatResult "padded"


### PR DESCRIPTION
## About

Add `format` flag for the `list` command, supporting `padded` (as before) and `json` output formats.